### PR TITLE
Add "slim" create_model interface for Pyomo.DoE

### DIFF
--- a/pyomo/contrib/doe/doe.py
+++ b/pyomo/contrib/doe/doe.py
@@ -42,6 +42,7 @@ import collections.abc
 
 import inspect
 
+import pyomo.contrib.parmest.utils as utils
 
 class CalculationMode(Enum):
     sequential_finite = "sequential_finite"
@@ -114,6 +115,15 @@ class DesignOfExperiments:
         self.design_name = design_vars.variable_names
         self.design_vars = design_vars
         self.create_model = create_model
+
+        # check if create model function conforms to the original
+        # Pyomo.DoE interface
+        model_option_arg = "model_option" in inspect.getfullargspec(self.create_model).args
+        mod_arg = "mod" in inspect.getfullargspec(self.create_model).args
+        if model_option_arg and mod_arg:
+            self._original_create_model_interface = True
+        else:
+            self._original_create_model_interface = False
 
         if args is None:
             args = {}
@@ -423,10 +433,17 @@ class DesignOfExperiments:
             # dict for storing model outputs
             output_record = {}
 
+            # Deactivate any existing objective functions
+            for obj in mod.component_objects(pyo.Objective):
+                obj.deactivate()
+
             # add zero (dummy/placeholder) objective function
             mod.Obj = pyo.Objective(expr=0, sense=pyo.minimize)
 
-            mod.pprint()
+            # convert params to vars
+            # print("self.param.keys():", self.param.keys())
+            # mod = utils.convert_params_to_vars(mod, self.param.keys(), fix_vars=True)
+            # mod.pprint()
 
             # solve model
             square_result = self._solve_doe(mod, fix=True)
@@ -495,14 +512,24 @@ class DesignOfExperiments:
 
     def _direct_kaug(self):
         # create model
-        mod = self.create_model(model_option=ModelOptionLib.parmest, **self.args)
+        if self._original_create_model_interface:
+            mod = self.create_model(model_option=ModelOptionLib.parmest, **self.args)
+        else:
+            mod = self.create_model(**self.args)
 
         # discretize if needed
         if self.discretize_model is not None:
             mod = self.discretize_model(mod, block=False)
 
+        # Deactivate any existing objective functions
+        for obj in mod.component_objects(pyo.Objective):
+            obj.deactivate()
+
         # add zero (dummy/placeholder) objective function
         mod.Obj = pyo.Objective(expr=0, sense=pyo.minimize)
+
+        # convert params to vars
+        # mod = utils.convert_params_to_vars(mod, self.param.keys(), fix_vars=True)
 
         # set ub and lb to parameters
         for par in self.param.keys():
@@ -608,19 +635,37 @@ class DesignOfExperiments:
         self.eps_abs = self.scenario_data.eps_abs
         self.scena_gen = scena_gen
 
-        # Create a global model
-        mod = pyo.ConcreteModel()
-
-        # Set for block/scenarios
-        mod.scenario = pyo.Set(initialize=self.scenario_data.scenario_indices)
-
         # Determine if create_model takes theta as an optional input
         pass_theta_to_initialize = (
             "theta" in inspect.getfullargspec(self.create_model).args
         )
 
         # Allow user to self-define complex design variables
-        self.create_model(mod=mod, model_option=ModelOptionLib.stage1, **self.args)
+        if self._original_create_model_interface:
+
+            # Create a global model
+            mod = pyo.ConcreteModel()
+
+            if pass_theta_to_initialize:
+                # Add model on block with theta values
+                self.create_model(
+                    mod=mod,
+                    model_option=ModelOptionLib.stage1,
+                    theta=self.param,
+                    **self.args,
+                )
+            else:
+                # Add model on block without theta values
+                self.create_model(mod=mod, 
+                                  model_option=ModelOptionLib.stage1, 
+                                  **self.args)
+
+        else:
+            # Create a global model
+            mod = self.create_model(**self.args)
+
+        # Set for block/scenarios
+        mod.scenario = pyo.Set(initialize=self.scenario_data.scenario_indices)
 
         # Fix parameter values in the copy of the stage1 model (if they exist)
         for par in self.param:
@@ -635,21 +680,33 @@ class DesignOfExperiments:
             # create block scenarios
             # idea: check if create_model takes theta as an optional input, if so, pass parameter values to create_model
 
-            if pass_theta_to_initialize:
-                # Grab the values of theta for this scenario/block
-                theta_initialize = self.scenario_data.scenario[s]
-                # Add model on block with theta values
-                self.create_model(
-                    mod=b,
-                    model_option=ModelOptionLib.stage2,
-                    theta=theta_initialize,
-                    **self.args,
-                )
+            # TODO: Check if this is correct syntax for adding a model to a block
+
+            if self._original_create_model_interface:
+                if pass_theta_to_initialize:
+                    # Grab the values of theta for this scenario/block
+                    theta_initialize = self.scenario_data.scenario[s]
+                    # Add model on block with theta values
+                    self.create_model(
+                        mod=b,
+                        model_option=ModelOptionLib.stage2,
+                        theta=theta_initialize,
+                        **self.args,
+                    )
+                else:
+                    # Otherwise add model on block without theta values
+                    self.create_model(
+                        mod=b, model_option=ModelOptionLib.stage2, **self.args
+                    )
             else:
-                # Otherwise add model on block without theta values
-                self.create_model(
-                    mod=b, model_option=ModelOptionLib.stage2, **self.args
-                )
+                # Add model on block
+                if pass_theta_to_initialize:
+                    # Grab the values of theta for this scenario/block
+                    theta_initialize = self.scenario_data.scenario[s]
+                    # This syntax is not yet correct :(
+                    b = self.create_model(theta=theta_initialize, **self.args)
+                else:
+                    b = self.create_model(**self.args)
 
             # fix parameter values to perturbed values
             for par in self.param:

--- a/pyomo/contrib/doe/examples/reactor_design.py
+++ b/pyomo/contrib/doe/examples/reactor_design.py
@@ -40,8 +40,10 @@ from pyomo.contrib.doe import (
 from pyomo.common.dependencies import numpy as np
 
 
-def create_model(mod=None, model_option="stage2"):
+def create_model():
 
+    # This is the old Pyomo.DoE interface
+    '''
     model_option = ModelOptionLib(model_option)
 
     model = mod
@@ -59,6 +61,10 @@ def create_model(mod=None, model_option="stage2"):
         raise ValueError(
             "model_option needs to be defined as parmest, stage1, or stage2."
         )
+    '''
+
+    # This is the streamlined Pyomo.DoE interface
+    model = pyo.ConcreteModel()
 
     # Rate constants
     model.k1 = pyo.Var(initialize=5.0 / 6.0, within=pyo.PositiveReals)  # min^-1
@@ -102,8 +108,11 @@ def create_model(mod=None, model_option="stage2"):
         expr=(0 == -model.sv * model.cd + model.k3 * model.ca**2.0)
     )
 
+    '''
     if return_m:
         return model
+    '''
+    return model
 
 
 def main():

--- a/pyomo/contrib/doe/tests/test_example.py
+++ b/pyomo/contrib/doe/tests/test_example.py
@@ -68,11 +68,17 @@ class TestReactorExample(unittest.TestCase):
     @unittest.skipIf(not ipopt_available, "The 'ipopt' command is not available")
     @unittest.skipIf(not pandas_available, "pandas is not available")
     @unittest.skipIf(not numpy_available, "Numpy is not available")
-    def test_reactor_design(self):
+    def test_reactor_design_slim_create_model_interface(self):
         from pyomo.contrib.doe.examples import reactor_design
-
-        reactor_design.main()
-
+        reactor_design.main(legacy_create_model_interface=False)
+    
+    @unittest.skipIf(not ipopt_available, "The 'ipopt' command is not available")
+    @unittest.skipIf(not pandas_available, "pandas is not available")
+    @unittest.skipIf(not numpy_available, "Numpy is not available")
+    
+    def test_reactor_design_legacy_create_model_interface(self):
+        from pyomo.contrib.doe.examples import reactor_design
+        reactor_design.main(legacy_create_model_interface=True)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
- This simplifies the `create_model` interface in Pyomo.DoE to be much closer to ParmEst
- Legacy interface will be removed as part of the ParmEst/Pyomo.DoE refactor

## Changes proposed in this PR:
- Added detection for new interface, still supports legacy interface

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
