### PR TITLE
Pyomo doe fim symmetry

### DIFF
--- a/pyomo/contrib/doe/doe.py
+++ b/pyomo/contrib/doe/doe.py
@@ -1028,8 +1028,14 @@ class DesignOfExperiments:
 
         # Developer recommendation: use the Cholesky decomposition for D-optimality
         # The explicit formula is available for benchmarking purposes and is NOT recommended
-        if self.only_compute_fim_lower and self.objective_option == ObjectiveLib.det and not self.Cholesky_option:
-            raise ValueError("Cannot compute determinant with explicit formula if only_compute_fim_lower is True.")
+        if (
+            self.only_compute_fim_lower
+            and self.objective_option == ObjectiveLib.det
+            and not self.Cholesky_option
+        ):
+            raise ValueError(
+                "Cannot compute determinant with explicit formula if only_compute_fim_lower is True."
+            )
 
         model = self._create_block()
 

--- a/pyomo/contrib/doe/doe.py
+++ b/pyomo/contrib/doe/doe.py
@@ -1175,17 +1175,21 @@ class DesignOfExperiments:
             p: parameter
             q: parameter
             """
-            return (
-                m.fim[p, q]
-                == sum(
-                    1
-                    / self.measurement_vars.variance[n]
-                    * m.sensitivity_jacobian[p, n]
-                    * m.sensitivity_jacobian[q, n]
-                    for n in model.measured_variables
+
+            if p > q:
+                return m.fim[p, q] == m.fim[q, p]
+            else:
+                return (
+                    m.fim[p, q]
+                    == sum(
+                        1
+                        / self.measurement_vars.variance[n]
+                        * m.sensitivity_jacobian[p, n]
+                        * m.sensitivity_jacobian[q, n]
+                        for n in model.measured_variables
+                    )
+                    + m.priorFIM[p, q] * self.fim_scale_constant_value
                 )
-                + m.priorFIM[p, q] * self.fim_scale_constant_value
-            )
 
         model.jacobian_constraint = pyo.Constraint(
             model.regression_parameters, model.measured_variables, rule=jacobian_rule

--- a/pyomo/contrib/doe/doe.py
+++ b/pyomo/contrib/doe/doe.py
@@ -1311,7 +1311,7 @@ class DesignOfExperiments:
                 m.regression_parameters, m.regression_parameters, rule=cholesky_imp
             )
             m.Obj = pyo.Objective(
-                expr=2 * sum(pyo.log(m.L_ele[j, j]) for j in m.regression_parameters),
+                expr=2 * sum(pyo.log10(m.L_ele[j, j]) for j in m.regression_parameters),
                 sense=pyo.maximize,
             )
 
@@ -1319,13 +1319,13 @@ class DesignOfExperiments:
             # if not cholesky but determinant, calculating det and evaluate the OBJ with det
             m.det = pyo.Var(initialize=np.linalg.det(fim), bounds=(small_number, None))
             m.det_rule = pyo.Constraint(rule=det_general)
-            m.Obj = pyo.Objective(expr=pyo.log(m.det), sense=pyo.maximize)
+            m.Obj = pyo.Objective(expr=pyo.log10(m.det), sense=pyo.maximize)
 
         elif self.objective_option == ObjectiveLib.trace:
             # if not determinant or cholesky, calculating the OBJ with trace
             m.trace = pyo.Var(initialize=np.trace(fim), bounds=(small_number, None))
             m.trace_rule = pyo.Constraint(rule=trace_calc)
-            m.Obj = pyo.Objective(expr=pyo.log(m.trace), sense=pyo.maximize)
+            m.Obj = pyo.Objective(expr=pyo.log10(m.trace), sense=pyo.maximize)
             # m.Obj = pyo.Objective(expr=m.trace, sense=pyo.maximize)
 
         elif self.objective_option == ObjectiveLib.zero:

--- a/pyomo/contrib/doe/examples/reactor_design.py
+++ b/pyomo/contrib/doe/examples/reactor_design.py
@@ -206,10 +206,9 @@ def main(legacy_create_model_interface=False):
     )
 
     optimize_result2.result_analysis()
-    log_det = np.log(optimize_result2.det)
+    log_det = np.log10(optimize_result2.det)
     print("log(det) = ", round(log_det, 3))
-    #log_det_expected = 45.199
-    log_det_expected = 44.362
+    log_det_expected = 19.266
     assert abs(log_det - log_det_expected) < 0.01, "log(det) regression test failed"
 
     doe3 = DesignOfExperiments(
@@ -225,8 +224,8 @@ def main(legacy_create_model_interface=False):
     )
 
     optimize_result3.result_analysis()
-    log_trace = np.log(optimize_result3.trace)
-    log_trace_expected = 17.29
+    log_trace = np.log10(optimize_result3.trace)
+    log_trace_expected = 7.509
     print("log(trace) = ", round(log_trace, 3))
     assert (
         abs(log_trace - log_trace_expected) < 0.01

--- a/pyomo/contrib/doe/examples/reactor_design.py
+++ b/pyomo/contrib/doe/examples/reactor_design.py
@@ -162,7 +162,7 @@ def main(legacy_create_model_interface=False):
         formula="central",  # formula for finite difference
     )
 
-    doe1.model.pprint()
+    # doe1.model.pprint()
 
     result.result_analysis()
 
@@ -208,7 +208,8 @@ def main(legacy_create_model_interface=False):
     optimize_result2.result_analysis()
     log_det = np.log(optimize_result2.det)
     print("log(det) = ", round(log_det, 3))
-    log_det_expected = 45.199
+    #log_det_expected = 45.199
+    log_det_expected = 44.362
     assert abs(log_det - log_det_expected) < 0.01, "log(det) regression test failed"
 
     doe3 = DesignOfExperiments(


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
- Pyomo.DoE took too many iterations for TCLab workshop example

## Changes proposed in this PR:
- Added two symmetry exploiting options
- Option 1: Above the diagonal of the FIM, use equality constraint fim[i,j] = fim[j,i]. Thus the "heavy lifting" is only done on and below the diagonal
- Option 2: Skip constraint to calculate above the diagonal of the FIM.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
